### PR TITLE
Enable Firefox WebExtensions compatibility

### DIFF
--- a/background.js
+++ b/background.js
@@ -24,7 +24,7 @@ var userStorage = new ChromeStorage({ // Collect basic targeting data across use
 		}});
 
 		// If popup opens, close any access_token notification prompts
-		chrome.extension.onMessage.addListener(function(request,sender,sendResponse) {
+		chrome.runtime.onMessage.addListener(function(request,sender,sendResponse) {
 		    if(request.notification === "hide") checkAccessToken();
 		    if(request.access_token_received) checkAccessToken(request.access_token_received);
 		})

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,11 @@
 	"name": "Who Targets Me",
 	"manifest_version": 2,
 	"description": "Track which entities are targeting you with adverts",
+	"applications": {
+		"gecko": {
+			"id": "whotargetsme@whotargets.me"
+		}
+	},
 	"browser_action": {
 		"default_title": "Who targets me?",
 		"default_popup": "popup.html",

--- a/popup.js
+++ b/popup.js
@@ -21,7 +21,7 @@ var browserStorage = new ChromeStorage({ // Collect basic targeting data across 
 
 
 // Hide notification for access_token, if it has been set
-chrome.extension.sendMessage({notification: "hide"});
+chrome.runtime.sendMessage({notification: "hide"});
 
 // Can't access var until it's sync'd
 userStorage.onLoad({ 'access_token': start() })
@@ -120,7 +120,7 @@ function isFormValid() {
 		if(response.data.access_token) {
 			userStorage.set('access_token', response.data.access_token, function() {
 				userStorage.set('dateTokenGot', Date.now(), function() {
-					chrome.extension.sendMessage({access_token_received: userStorage.dateTokenGot});
+					chrome.runtime.sendMessage({access_token_received: userStorage.dateTokenGot});
 				});
 
 				$("#loading").hide();


### PR DESCRIPTION
This change allows the extension to run in Firefox as well as
in Chrome.

There are two changes:

- Replacing chrome.extension.* message passing functions with chrome.runtime.*: note that using chrome.runtime.* is what is listed on the chrome extension [documentation](https://developer.chrome.com/extensions/messaging) as well. 
- Add application id (required by Firefox) to manifest

After this pull request, you can simply zip the folder into an `.xpi` file, and it can be distributed on addons.mozilla.org