### PR TITLE
Extension Icon Fails to Open Our Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.1",
   "description": "Track the extent of digital political advertising, discover which parties are targeting you",
   "main": "index.js",
-  "apiUrl": "http://localhost:3000/dev/",
+  "apiUrl": "https://wtm-api.whotargets.me/v1/",
   "apiUrlLocal": "http://localhost:3000/",
   "resultsUrl": "https://results.whotargets.me/",
   "resultsUrlLocal": "http://localhost:3000/",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.1",
   "description": "Track the extent of digital political advertising, discover which parties are targeting you",
   "main": "index.js",
-  "apiUrl": "https://wtm-api.whotargets.me/v1/",
+  "apiUrl": "http://localhost:3000/dev/",
   "apiUrlLocal": "http://localhost:3000/",
   "resultsUrl": "https://results.whotargets.me/",
   "resultsUrlLocal": "http://localhost:3000/",

--- a/src/daemon/background/index.js
+++ b/src/daemon/background/index.js
@@ -120,16 +120,12 @@ chrome.browserAction && chrome.browserAction.onClicked.addListener(function(tab)
       // toolbar button clicked Chrome
       try {
         chrome.tabs.query({active: false, currentWindow: true}, function(tabs) {
-          for (let i=tabs.length; i > -1; i--) {
-            try {
-              chrome.tabs.create({ url: url });
-              break;
-            } catch (e) {
-              browser.tabs.create({
-                url
-              });
-              break;
-            }
+          try {
+            chrome.tabs.create({ url: url });
+          } catch (e) {
+            browser.tabs.create({
+              url
+            });
           }
         });
     } catch(e) {

--- a/src/daemon/background/index.js
+++ b/src/daemon/background/index.js
@@ -120,29 +120,15 @@ chrome.browserAction && chrome.browserAction.onClicked.addListener(function(tab)
       // toolbar button clicked Chrome
       try {
         chrome.tabs.query({active: false, currentWindow: true}, function(tabs) {
-          if (tabs.length > 1) {
-            for (let i=tabs.length-1; i > -1; i--) {
-              if (tabs[i].url !== "chrome://extensions/") {
-                const currTab = tabs[i];
-                // console.log('currTab', currTab, tabs)
-                try {
-                  chrome.tabs.update(currTab.id, {selected: true});
-                } catch (e) {
-                  browser.tabs.create({
-                    url
-                  });
-                  break;
-                }
-                chrome.tabs.executeScript(currTab.id, {
-                  code: `window.open("${url}", "_blank")`
-                }, r => {
-                    let e = chrome.runtime.lastError;
-                    if (e !== undefined){
-                      console.log(currTab, r, e);
-                    };
-                })
-                break;
-              }
+          for (let i=tabs.length; i > -1; i--) {
+            try {
+              chrome.tabs.create({ url: url });
+              break;
+            } catch (e) {
+              browser.tabs.create({
+                url
+              });
+              break;
             }
           }
         });


### PR DESCRIPTION
## Related Ticket

[This Jira ticket](https://whotargetsme.atlassian.net/browse/WTM-512) explains the bug and lays out the steps needed to reproduce the bug. 

## Solution
For some unexplainable reason, previously we were trying to update the URL of current tab that was open and we did so only when more than two tabs were open. That created the issue with updating URLs because if the tab is empty and has no pages open, there is no URL to replace it with. 

Also, it does not make sense to check for the number of tabs open and only then open our web page. The browser is not going to be open if there are no tabs to begin with. I suspect these logics were necessary in the older days, but no longer are.