### PR TITLE
Allowing Overwrite of Build Directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build:firefox": "BROWSER=firefox webpack --config src/build/webpack.daemon.config.js",
     "dev-daemon": "OFFLINE=true BROWSER=chrome webpack --config src/build/webpack.daemon.config.js --watch",
     "package:all": "npm run package:chrome && npm run package:firefox",
-    "package:chrome": "npm run build:chrome && web-ext build --source-dir ./build/chrome --filename 'chrome-{version}.zip' --artifacts-dir ./build/chrome",
-    "package:firefox": "npm run build:firefox && web-ext build --source-dir ./build/firefox --filename 'firefox-{version}.zip' --artifacts-dir ./build/firefox",
+    "package:chrome": "npm run build:chrome && web-ext build --source-dir ./build/chrome --filename 'chrome-{version}.zip' --artifacts-dir ./build/chrome --overwrite-dest",
+    "package:firefox": "npm run build:firefox && web-ext build --source-dir ./build/firefox --filename 'firefox-{version}.zip' --artifacts-dir ./build/firefox --overwrite-dest",
     "start:chrome": "web-ext run --target chromium --source-dir ./build/chrome/",
     "start:firefox": "web-ext run --source-dir ./build/firefox/"
   },


### PR DESCRIPTION
Instead of having to remove the `build` directory every time you want to make a new build of the extension, the `--overwrite-dest` will help in overwriting