### PR TITLE
Storing User Token When A Message is Posted from Results Page

### DIFF
--- a/src/daemon/background/index.js
+++ b/src/daemon/background/index.js
@@ -57,6 +57,8 @@ window.addEventListener("message", function (event) {
   } else if (event.data.deleteWTMUser) {
     chrome.storage.promise.local.remove("general_token");
     chrome.storage.promise.local.remove("userData");
+  } else if (event.data.storeUserToken) {
+    chrome.storage.promise.local.set({ general_token: event.data.token })
   }
 });
 


### PR DESCRIPTION
## Related Ticket/PR
- [Jira ticket](https://whotargetsme.atlassian.net/jira/software/c/projects/WTM/boards/4?modal=detail&selectedIssue=WTM-548)
- [Results Page PR](https://github.com/WhoTargetsMe/wtm-results-frontend/pull/60)

## Changes
We want to store the user token that is sent from the extension