### PR TITLE
feat(WTM-958): reduced waist data to just the expandable panels

### DIFF
--- a/src/daemon/collector/platforms/youtube/handleCollectWaistData.js
+++ b/src/daemon/collector/platforms/youtube/handleCollectWaistData.js
@@ -1,4 +1,5 @@
 import { findRenderers } from ".";
+import { load } from "cheerio";
 
 export const getYoutubeAdvertisementWaistData = async (adSlotRenderer) => {
   const aboutThisAdRenderer = findRenderers(adSlotRenderer, "aboutThisAdRenderer")?.[0];
@@ -7,7 +8,19 @@ export const getYoutubeAdvertisementWaistData = async (adSlotRenderer) => {
 
   if (url) {
     const html = await fetchWaistData(url);
-    return html;
+
+    const $ = load(html);
+
+    try {
+      let filteredSubsections = $("div[role=region]").filter(function () {
+        return $(this).find("span[role=heading]").length > 0;
+      });
+
+      return filteredSubsections?.toString();
+    }
+    catch (e) {
+      console.error("Error parsing waist data: ", e);
+    }
   }
 
   return;


### PR DESCRIPTION
# (WTM-958) Extension // Analysis of html waist data

## Related Ticket/PR
- [Jira ticket](https://whotargetsme.atlassian.net/browse/WTM-958)

---

## Changes
The waist data collected the whole popup modal html for later parser. However, after inspecting noted that it contains the users email details amongst other details.

Used cheerio library to select just the relevant sections of the html from the model.

I.e. the type of page

<img width="420" alt="image" src="https://github.com/user-attachments/assets/a27e9ca0-bafd-4766-8765-e1befcc11c89">

gets reduced to 

<img width="683" alt="image" src="https://github.com/user-attachments/assets/e99f2ec7-3de7-4b69-b922-18a1e7e2506e">


---


- [ ✓ ] Rawlogs can be successfully captured 

