### PR TITLE
chore(WTM-962): Add additional youtube api for capturing advert data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whotargetsme/who-targets-me",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Track the extent of digital political advertising, discover which parties are targeting you",
   "main": "index.js",
   "dataApi": "https://data-api.whotargets.me",

--- a/src/daemon/collector/platforms/youtube/handleApiResponse.js
+++ b/src/daemon/collector/platforms/youtube/handleApiResponse.js
@@ -10,9 +10,10 @@ import { postYouTubeSponsoredData } from "../../overload/post-sponsored-data";
 // PLAYER is hit when you mouse over a video whilst browsing (It also seems to run mometaily before running NEXT when you've clicked on a video, but doesn't seem to contain ad data in that case)
 // NEXT is hit when you click on a video, and are actually watching it
 // REEL_ITEM_WATCH is hit when you're watching a youtube short
+// AD_BREAK is in between watching a video
 
 export const handleYoutubeResponse = async (url, response) => {
-  const regexList = [/v1\/(search|browse|player|next|reel\/reel_item_watch)\?prettyPrint=false/g];
+  const regexList = [/v1\/(search|browse|player|next|ad_break|reel\/reel_item_watch)\?prettyPrint=false/g];
 
   const isURLInterested = (url) => {
     return regexList.some((regex) => regex.test(url));


### PR DESCRIPTION
# (WTM-962) Add additional youtube api for capturing advert data

## Related Ticket/PR
- [Jira ticket](https://whotargetsme.atlassian.net/browse/WTM-962)

---

## Changes
This PR changes ...
- small change to add an additonal api to capture adverts
- also, bumped the version

- [ ✓] Rawlogs can be successfully captured 

