### PR TITLE
fix: add new detection for sponsored posts

### DIFF
--- a/src/build/v2.manifest.template.json
+++ b/src/build/v2.manifest.template.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.1",
+  "version": "1.10.2",
   "name": "__MSG_appName__",
   "manifest_version": 2,
   "description": "__MSG_appDesc__",
@@ -7,10 +7,7 @@
   "browser_action": {
     "default_icon": "wtm_logo_128.png"
   },
-  "permissions": [
-    "storage",
-    "tabs"
-  ],
+  "permissions": ["storage", "tabs"],
   "content_scripts": [
     {
       "js": ["daemon/index.js"]

--- a/src/build/v3.manifest.template.json
+++ b/src/build/v3.manifest.template.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.1",
+  "version": "2.4.2",
   "name": "__MSG_appName__",
   "manifest_version": 3,
   "description": "__MSG_appDesc__",

--- a/src/daemon/collector/platforms/facebook/handleApiResponse.js
+++ b/src/daemon/collector/platforms/facebook/handleApiResponse.js
@@ -37,6 +37,9 @@ export const handleApiResponse = async (url, response) => {
 const containsSponsoredResponse = (response) => {
   return (
     response.category === "SPONSORED" ||
+    // 2024-08-25: Category has since been encoded as field `category_enc`
+    //  Try to detect based on presence of sponsored_data content
+    _.has(response, "node.sponsored_data.ad_id") ||
     _.get(response, "viewer.sideFeed.nodes[0].__typename", "") === "AdsSideFeedUnit"
   );
 };

--- a/src/daemon/collector/platforms/facebook/handleInlineContent.js
+++ b/src/daemon/collector/platforms/facebook/handleInlineContent.js
@@ -12,6 +12,9 @@ export const handleInlineContent = async () => {
 const handleAdsInDocument = () => {
   const sideAdRegex = /AdsSideFeedUnit/g;
   const postAdRegex = /"category":"SPONSORED"/g;
+  // 2024-08-25: Category has since been encoded as field `category_enc`
+  //  Try to detect based on presence of sponsored_data content
+  const postAdRegex2 = /\{"sponsored_data":\{"/g;
 
   $('script[type="application/json"]').each((_i, el) => {
     const content = $(el).text();
@@ -21,6 +24,10 @@ const handleAdsInDocument = () => {
     }
 
     if (postAdRegex.test(content)) {
+      handleFeedAds(JSON.parse(content));
+    }
+
+    if (postAdRegex2.test(content)) {
       handleFeedAds(JSON.parse(content));
     }
   });


### PR DESCRIPTION
Following changes to Facebook categorixation in docs, now detect sponsored based on existance to sponsored data